### PR TITLE
feat: Add prometheus metrics to Meteor Shower

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,4 +2,11 @@
 // we need to transpile the modules before we can use them.
 const withTM = require('next-transpile-modules')(['@patternfly/react-core', '@patternfly/react-styles', '@patternfly/react-log-viewer']);
 
-module.exports = withTM();
+// Default metrics needs to be registered only once and at the startup
+const client = require('prom-client');
+client.collectDefaultMetrics();
+
+module.exports = withTM({
+  // Handle `/metrics` calls as if it is a call to `/api/metrics`
+  rewrites: async () => [{ source: '/metrics', destination: '/api/metrics' }],
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -913,6 +913,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "bn.js": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
@@ -3921,6 +3926,14 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "prom-client": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.1.0.tgz",
+      "integrity": "sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -4754,6 +4767,14 @@
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
       }
     },
     "text-table": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@patternfly/react-log-viewer": "^4.1.19",
     "next": "^11.0.0",
     "next-transpile-modules": "^8.0.0",
+    "prom-client": "^13.1.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,19 @@
+import { collectDefaultMetrics, Counter, register } from 'prom-client';
+
+// Prometheus client doesn't like how NextJS re-imports and re-evaluates all changes with hot reloading.
+// Hence to support hot reloading we need to flush existing metrics registry in case a page containing a metric was changed.
+if (process.env.NODE_ENV == 'development') {
+  register.clear();
+  collectDefaultMetrics();
+}
+
+// Arbitrary metrics counting page hits
+export const httpRequestsTotal = new Counter({
+  name: 'http_requests_total',
+  help: 'Total requests received',
+  labelNames: ['method', 'statusCode', 'path'],
+});
+
+export default {
+  httpRequestsTotal,
+};

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -3,4 +3,14 @@ import App from 'next/app';
 import '@patternfly/react-core/dist/styles/base.css';
 import '../styles.css';
 
+// Populate initial props passed to the React application. Also serves as a middleware intercepting any incoming request.
+App.getInitialProps = async (appctx) => {
+  if (typeof window === 'undefined') {
+    // Only server-side evals should result in prometheus imports. Client side imports doesn't make sense here.
+    const metrics = require('../metrics');
+    metrics.httpRequestsTotal.labels({ method: appctx.ctx.req.method, statusCode: appctx.ctx.res.statusCode, path: appctx.ctx.req.url }).inc();
+  }
+  return {};
+};
+
 export default App;

--- a/src/pages/api/meteor/[id].ts
+++ b/src/pages/api/meteor/[id].ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getMeteor } from '../../../k8s';
 import { HttpStatusCode } from '../../../constants';
+import { httpRequestsTotal } from '../../../metrics';
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const {
@@ -12,12 +13,15 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const meteor = await getMeteor(id as string);
     if (meteor) {
       res.status(HttpStatusCode.OK).json(meteor);
+      httpRequestsTotal.labels({ method, statusCode: HttpStatusCode.OK, path: `/api/meteor/${id}` }).inc();
     } else {
       res.status(HttpStatusCode.NOT_FOUND).end('Not Found');
+      httpRequestsTotal.labels({ method, statusCode: HttpStatusCode.NOT_FOUND, path: `/api/meteor/${id}` }).inc();
     }
   } else {
     res.status(HttpStatusCode.METHOD_NOT_ALLOWED).setHeader('Allow', ['GET']);
     res.end(`Method ${method} Not Allowed`);
+    httpRequestsTotal.labels({ method, statusCode: HttpStatusCode.METHOD_NOT_ALLOWED, path: `/api/meteor/${id}` }).inc();
   }
 };
 

--- a/src/pages/api/meteors.ts
+++ b/src/pages/api/meteors.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { listMeteors, createMeteor } from '../../k8s';
 import { HttpStatusCode } from '../../constants';
+import { httpRequestsTotal } from '../../metrics';
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { body, method } = req;
@@ -8,12 +9,15 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const meteor = await createMeteor(body);
     res.status(HttpStatusCode.CREATED).setHeader('Location', `/api/meteor/${meteor.metadata.name}`);
     res.json(meteor);
+    httpRequestsTotal.labels({ method, statusCode: HttpStatusCode.CREATED, path: '/api/meteors' }).inc();
   } else if (method === 'GET') {
     const meteors = await listMeteors();
     res.status(HttpStatusCode.OK).json(meteors.map((m: any) => m.metadata.name));
+    httpRequestsTotal.labels({ method, statusCode: HttpStatusCode.OK, path: '/api/meteors' }).inc();
   } else {
     res.status(HttpStatusCode.METHOD_NOT_ALLOWED).setHeader('Allow', ['GET', 'POST']);
     res.end(`Method ${method} Not Allowed`);
+    httpRequestsTotal.labels({ method, statusCode: HttpStatusCode.METHOD_NOT_ALLOWED, path: '/api/meteors' }).inc();
   }
 };
 

--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -1,0 +1,12 @@
+import { NextApiResponse } from 'next';
+import { register } from 'prom-client';
+import { httpRequestsTotal } from '../../metrics';
+
+// Metrics endpoint. Hits to `/metrics` are forwarded to this `/api/metrics` endpoint as well via next.config.js `rewrites`.
+const metrics = async (_, res: NextApiResponse) => {
+  res.setHeader('Content-type', register.contentType);
+  res.end(await register.metrics());
+  httpRequestsTotal.labels({ method: 'GET', statusCode: '200', path: '/metrics' }).inc();
+};
+
+export default metrics;


### PR DESCRIPTION
Part of: https://github.com/AICoE/meteor/issues/51

Enables `/metrics` endpoint with default nodejs metrics + `http_requests_total`