### PR TITLE
chore: Make dependabot use ok-to-test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,9 @@
 
 version: 2
 updates:
-    - package-ecosystem: npm
-      directory: "/"
-      schedule:
-          interval: daily
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    labels:
+      - ok-to-test


### PR DESCRIPTION
Remove the need for me to apply `ok-to-test` every time dependabot opens a PR.